### PR TITLE
split lhs at first window width and render remain lhs on top right window

### DIFF
--- a/perspeen-tab.el
+++ b/perspeen-tab.el
@@ -239,13 +239,16 @@ Argument OTHER-FACE the face of un-selected tabs."
 		(powerline-render lhs)
 		(powerline-fill 'perspeen-tab--powerline-inactive1 (powerline-width rhs))
 		(powerline-render rhs))
-	     (concat
-	      (powerline-render lhs)
-	      (powerline-fill 'perspeen-tab--powerline-inactive1 0))))
+       (let ((lhs-str (powerline-render lhs)))
+         (concat
+          (substring lhs-str 0 (min (length lhs-str) (window-width first-window)))
+          (powerline-fill 'perspeen-tab--powerline-inactive1 0)))))
 	  ((eq current-window top-right-window)
-	   (concat
-	    (powerline-fill 'perspeen-tab--powerline-inactive1 (powerline-width rhs))
-	    (powerline-render rhs)))
+     (let ((lhs-str (powerline-render lhs)))
+       (concat
+        (substring lhs-str (min (length lhs-str) (window-width first-window)))
+        (powerline-fill 'perspeen-tab--powerline-inactive1 (powerline-width rhs))
+        (powerline-render rhs))))
 	  (t
 	   nil))))
 


### PR DESCRIPTION
when window is splitted vertically, top right window has no header line (before),  simply split lhs at first window width and render rest of lhs at top right window (after).
it is much better that not to rendered at both left window and right window when tab is splitted.

|before|after|after'|
|---|---|---|
|![deepinscreenshot20170709170849](https://user-images.githubusercontent.com/3055271/27992583-127e713c-64d3-11e7-9b4c-e624d2bc0719.png)|![deepinscreenshot20170709170802](https://user-images.githubusercontent.com/3055271/27992585-18b6e69c-64d3-11e7-8cfb-fba364e4e0ed.png)|![deepinscreenshot20170709170739](https://user-images.githubusercontent.com/3055271/27992586-1d5df064-64d3-11e7-9584-11602904ed01.png)|

